### PR TITLE
fix: identity propagation check always failing due to property name mismatch

### DIFF
--- a/src/components/CreateDigitalId.jsx
+++ b/src/components/CreateDigitalId.jsx
@@ -156,10 +156,10 @@ function CreateDigitalId({ service }) {
           }
 
           setIsProcessing(true);
-          const identityAddress = await UserService.getIdentityByEmail(userEmail);
+          const identityResult = await UserService.getIdentityByEmail(userEmail);
 
           const { initiateResponse, error: initError } = await DfnsService.initiateUnlinkWallet(
-            identityAddress,
+            identityResult?.identityAddress,
             wallet.walletAddress,
             user.walletId,
             dfnsToken
@@ -435,7 +435,8 @@ function CreateDigitalId({ service }) {
       // Step 1: Check if identity already exists
       if (!identity || identity === "0x0000000000000000000000000000000000000000") {
         try {
-          identity = await retryWithBackoff(async () => await UserService.getIdentityByEmail(userEmail), 8, "Get existing identity");
+          const existingResult = await retryWithBackoff(async () => await UserService.getIdentityByEmail(userEmail), 8, "Get existing identity");
+          identity = existingResult?.identityAddress;
           console.log("Existing identity check:", identity);
 
           if (identity) {
@@ -528,10 +529,10 @@ function CreateDigitalId({ service }) {
           identityRegisteredOrExists = true;
         }
         await awaitTimeout(5000);
-        identity = await retryWithBackoff(
+        const createdResult = await retryWithBackoff(
           async () => {
             const result = await UserService.getIdentityByEmail(userEmail);
-            if (!result?.address) {
+            if (!result?.identityAddress) {
               throw new Error("Identity not yet propagated"); // force retry
             }
             return result;
@@ -539,7 +540,8 @@ function CreateDigitalId({ service }) {
           8,
           "Get created identity"
         );
-        console.log("New identity created:", identity.address);
+        identity = createdResult?.identityAddress;
+        console.log("New identity created:", identity);
         identityCreatedOrExists = true;
 
         saveOperationState(walletAddr, {
@@ -752,7 +754,8 @@ function CreateDigitalId({ service }) {
       // Step 1: Check if identity already exists
       if (!identity || identity === "0x0000000000000000000000000000000000000000") {
         try {
-          identity = await retryWithBackoff(async () => await UserService.getIdentityByEmail(userEmail), 8, "Get existing identity");
+          const existingResult = await retryWithBackoff(async () => await UserService.getIdentityByEmail(userEmail), 8, "Get existing identity");
+          identity = existingResult?.identityAddress;
           console.log("Existing identity check:", identity);
 
           if (identity) {
@@ -780,7 +783,8 @@ function CreateDigitalId({ service }) {
           await service.createIdentity(walletAddress);
           await awaitTimeout(2000);
 
-          identity = await retryWithBackoff(async () => await UserService.getIdentityByEmail(userEmail), 8, "Get existing identity");
+          const createdResult = await retryWithBackoff(async () => await UserService.getIdentityByEmail(userEmail), 8, "Get existing identity");
+          identity = createdResult?.identityAddress;
 
           console.log("New identity created:", identity);
           identityCreatedOrExists = true;

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -35,7 +35,7 @@ class UserService {
   getIdentityByEmail = async (email: string) => {
     try {
       const response = await Parse.Cloud.run("getIdentityAddressByEmail", { email });
-      return response?.identityAddress || null;
+      return response || null;
     } catch (error: any) {
       console.error(`Failed to get identity by email: ${error.message}`);
       return null;


### PR DESCRIPTION
## Summary

- `UserService.getIdentityByEmail` was stripping the cloud function response (`{ email, walletAddress, identityAddress, linkedWallets }`) down to just the `identityAddress` string, but the caller in `CreateDigitalId.jsx` checked `result?.address` — a property that never exists on a string. This caused every identity creation to fail after 8 retries (~27s of wasted polling), even when the identity was already in the database.
- Fixed `UserService.getIdentityByEmail` to return the full response object and updated all 5 call sites to extract `.identityAddress` and check `!result?.identityAddress`.

## Root cause
- UserService returned a string: return response?.identityAddress || null; // "0xfE260A38..."
- But the caller checked a property that doesn't exist on strings: if (!result?.address) { // always undefined → always retried throw new Error("Identity not yet propagated"); }


## Files changed

- `src/services/UserService.ts` — return full response object instead of just the address string
- `src/components/CreateDigitalId.jsx` — update all callers to use `?.identityAddress`

## Test plan

- [ ] Create a new digital identity via the Dfns (managed wallet) flow — should succeed on first propagation check without retries
- [ ] Verify existing identity lookup (Step 1) still short-circuits correctly when identity already exists